### PR TITLE
Corrected Docstrings for all files in pattern_structures folder  (#36)

### DIFF
--- a/paspailleur/pattern_structures/built_in_patterns.py
+++ b/paspailleur/pattern_structures/built_in_patterns.py
@@ -17,11 +17,11 @@ class ItemSetPattern(Pattern):
 
     References
     ----------
-    [1]: Agrawal, R., & Srikant, R. (1994). Fast algorithms for mining association rules in large databases.
+    Agrawal, R., & Srikant, R. (1994). Fast algorithms for mining association rules in large databases.
 
     Attributes
     ----------
-    PatternValueType :
+    PatternValueType:
         The type of the pattern's value, which is a frozenset.
 
     Properties
@@ -59,7 +59,8 @@ class ItemSetPattern(Pattern):
 
         Returns
         -------
-        str
+        representation: str
+
             The string representation of the item set pattern.
 
         Examples
@@ -93,7 +94,7 @@ class ItemSetPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another item set pattern to subtract from self.
 
         Returns
@@ -119,12 +120,12 @@ class ItemSetPattern(Pattern):
 
         Parameters
         ----------
-        value : str
+        value: str
             The string description of the item set pattern.
 
         Returns
         -------
-        PatternValueType
+        parsed: PatternValueType
             The parsed item set pattern value.
 
         Raises
@@ -169,12 +170,12 @@ class ItemSetPattern(Pattern):
 
         Parameters
         ----------
-        value : Collection
+        value: Collection
             The value to preprocess.
 
         Returns
         -------
-        PatternValueType
+        value: frozenset
             The preprocessed value as a frozenset.
 
         Examples
@@ -189,9 +190,11 @@ class ItemSetPattern(Pattern):
         """
         Return the set of all less precise patterns that cannot be obtained by intersection of other patterns.
 
+        For an ItemSetPattern an atomic pattern is a pattern containing one itme.
+
         Returns
         -------
-        set[Self]
+        atoms: set[Self]
             A set of atomic patterns, each containing a single item from the item set pattern.
 
         Examples
@@ -231,9 +234,9 @@ class CategorySetPattern(ItemSetPattern):
     
     Attributes
     ----------
-    PatternValueType :
+    PatternValueType:
         The type of the pattern's value, which is a frozenset.
-    Universe : Optional[frozenset]
+    Universe: Optional[frozenset]
         The set of all possible categories.
     
     Properties
@@ -255,7 +258,7 @@ class CategorySetPattern(ItemSetPattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another category set pattern to intersect with.
 
         Returns
@@ -278,7 +281,7 @@ class CategorySetPattern(ItemSetPattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another category set pattern to intersect with.
 
         Returns
@@ -301,7 +304,7 @@ class CategorySetPattern(ItemSetPattern):
 
         Returns
         -------
-        str
+        representation: str
             The string representation of the category set pattern.
 
         Examples
@@ -322,7 +325,7 @@ class CategorySetPattern(ItemSetPattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another category set pattern to subtract from self.
 
         Returns
@@ -347,9 +350,11 @@ class CategorySetPattern(ItemSetPattern):
         """
         Return the set of all less precise patterns that cannot be obtained by intersection of other patterns.
 
+        For a CategorySetPattern an atomic pattern is a set containing all-but-one categories.
+
         Returns
         -------
-        set[Self]
+        atoms: set[Self]
             A set of atomic patterns derived from the universe of categories.
 
         Raises
@@ -378,7 +383,7 @@ class CategorySetPattern(ItemSetPattern):
 
         Returns
         -------
-        Optional[Self]
+        min: Optional[Self]
             The minimal category set pattern or None if undefined.
 
         Examples
@@ -399,7 +404,7 @@ class CategorySetPattern(ItemSetPattern):
 
         Returns
         -------
-        Self
+        max: Self
             The maximal category set pattern, which is an empty frozenset.
 
         Examples
@@ -416,7 +421,7 @@ class CategorySetPattern(ItemSetPattern):
 
         Returns
         -------
-        int
+        length: int
             The number of categories not included in the category set pattern.
             The length of a pattern is the categories the pattern.value does _not_ include
 
@@ -446,9 +451,9 @@ class IntervalPattern(Pattern):
 
     Attributes
     ----------
-    PatternValueType :
+    PatternValueType:
         The type of the pattern's value, which is a tuple of bounds.
-    BoundsUniverse : list[float]
+    BoundsUniverse: list[float]
         A list representing the universe of bounds for the interval.
     
     Properties
@@ -504,7 +509,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        float
+        bound: float
             The lower bound of the interval.
 
         Examples
@@ -521,7 +526,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        bool
+        closed: bool
             True if the lower bound is closed, False otherwise.
 
         Examples
@@ -538,7 +543,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        float
+        bound: float
             The upper bound of the interval.
 
         Examples
@@ -555,7 +560,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        bool
+        closed: bool
             True if the upper bound is closed, False otherwise.
 
         Examples
@@ -571,7 +576,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        str
+        representation: str
             The string representation of the interval pattern.
 
         Examples
@@ -600,7 +605,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        int
+        count: int
             The number of non-infinite bounds in the interval.
 
         Examples
@@ -617,12 +622,12 @@ class IntervalPattern(Pattern):
 
         Parameters
         ----------
-        value : str
+        value: str
             The string description of the interval pattern.
 
         Returns
         -------
-        PatternValueType
+        parsed: PatternValueType
             The parsed interval pattern value.
 
         Examples
@@ -661,12 +666,12 @@ class IntervalPattern(Pattern):
 
         Parameters
         ----------
-        value :
+        value:
             The value to preprocess.
 
         Returns
         -------
-        PatternValueType
+        value: PatternValueType
             The preprocessed value as a tuple of bounds.
 
         Examples
@@ -699,7 +704,7 @@ class IntervalPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another interval pattern to union with.
 
         Returns
@@ -709,8 +714,8 @@ class IntervalPattern(Pattern):
 
         Notes
         -----
-        instead of having a normal intersection of intervals, we have an intersection of the restrictions meaning a union.
-        because the union is the only way to get the most presice interval pattern that is less precise than both self and other
+        Instead of having a normal intersection of intervals, we have an intersection of the restrictions meaning a union.
+        Because the union is the only way to get the most presice interval pattern that is less precise than both self and other
 
         Examples
         --------
@@ -752,7 +757,7 @@ class IntervalPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another interval pattern to union with.
 
         Returns
@@ -799,12 +804,11 @@ class IntervalPattern(Pattern):
 
     def __sub__(self, other: Self) -> Self:
         """
-
         Return the IntervalPattern that contains the items that can be found in self but not in other.
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another interval pattern to subtract from self.
 
         Returns
@@ -850,6 +854,10 @@ class IntervalPattern(Pattern):
         >>> p2 = IntervalPattern( "[1, 5]" )
         >>> p1 - p2
         [-inf, inf]
+
+        Warning
+        -------
+        The behavior of the function might change soon
         """
         if self == other:
             return self.min_pattern
@@ -872,9 +880,11 @@ class IntervalPattern(Pattern):
         """
         Return the set of all less precise patterns that cannot be obtained by intersection of other patterns.
 
+        For an IntervalPattern an atomic pattern is a half-bounded interval.
+
         Returns
         -------
-        set[Self]
+        atoms: set[Self]
             A set of atomic patterns derived from the interval.
 
         Examples
@@ -904,7 +914,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        Self
+        min: Self
             The minimal interval pattern, which is defined as (-inf, inf).
             `None` if undefined
 
@@ -922,7 +932,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        Self
+        max: Self
             The maximal interval pattern, which is represented as 'ø'.
 
         Examples
@@ -939,7 +949,7 @@ class IntervalPattern(Pattern):
 
         Returns
         -------
-        Optional[set[Self]]
+        max_atoms: Optional[set[Self]]
             A set of maximal atomic patterns or None if undefined.
 
         Examples
@@ -981,7 +991,7 @@ class ClosedIntervalPattern(IntervalPattern):
 
         Returns
         -------
-        float
+        bound: float
             The lower bound of the closed interval.
 
         Examples
@@ -998,7 +1008,7 @@ class ClosedIntervalPattern(IntervalPattern):
 
         Returns
         -------
-        float
+        bound: float
             The upper bound of the closed interval.
 
         Examples
@@ -1015,7 +1025,7 @@ class ClosedIntervalPattern(IntervalPattern):
 
         Returns
         -------
-        bool
+        closed: bool
             True, indicating that the lower bound is always closed.
 
         Examples
@@ -1032,7 +1042,7 @@ class ClosedIntervalPattern(IntervalPattern):
 
         Returns
         -------
-        bool
+        closed: bool
             True, indicating that the upper bound is always closed.
 
         Examples
@@ -1049,12 +1059,12 @@ class ClosedIntervalPattern(IntervalPattern):
 
         Parameters
         ----------
-        value : str
+        value: str
             The string description of the closed interval pattern.
 
         Returns
         -------
-        PatternValueType
+        parsed: PatternValueType
             The parsed closed interval pattern value.
 
         Raises
@@ -1082,12 +1092,12 @@ class ClosedIntervalPattern(IntervalPattern):
 
         Parameters
         ----------
-        value :
+        value:
             The value to preprocess.
 
         Returns
         -------
-        PatternValueType
+        value: PatternValueType
             The preprocessed value as a tuple of two floats.
 
         Raises
@@ -1118,9 +1128,9 @@ class NgramSetPattern(Pattern):
 
     Attributes
     ----------
-    PatternValueType :
+    PatternValueType:
         The type of the pattern's value, which is a frozenset of tuples.
-    StopWords : set[str]
+    StopWords: set[str]
         A set of exclusively stop words to be excluded from the n-grams.
         But if a set has both stop words and non stop words it is kept in the analysis
 
@@ -1151,7 +1161,7 @@ class NgramSetPattern(Pattern):
 
         Returns
         -------
-        str
+        representation: str
             The string representation of the n-gram set pattern.
 
         Examples
@@ -1172,12 +1182,12 @@ class NgramSetPattern(Pattern):
 
         Parameters
         ----------
-        value : str
+        value: str
             The string description of the n-gram set pattern.
 
         Returns
         -------
-        PatternValueType
+        parsed: PatternValueType
             The parsed n-gram set pattern value.
 
         Raises
@@ -1211,12 +1221,12 @@ class NgramSetPattern(Pattern):
 
         Parameters
         ----------
-        value :
+        value:
             The value to preprocess.
 
         Returns
         -------
-        PatternValueType
+        value: PatternValueType
             The preprocessed value as a frozenset of tuples.
 
         Examples
@@ -1234,7 +1244,7 @@ class NgramSetPattern(Pattern):
 
         Returns
         -------
-        int
+        count: int
             The number of n-grams.
 
         Examples
@@ -1258,7 +1268,7 @@ class NgramSetPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another n-gram set pattern to intersect with.
 
         Returns
@@ -1318,7 +1328,7 @@ class NgramSetPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another n-gram set pattern to union with.
 
         Returns
@@ -1342,7 +1352,7 @@ class NgramSetPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another n-gram set pattern to subtract from self.
 
         Returns
@@ -1369,14 +1379,14 @@ class NgramSetPattern(Pattern):
 
         Parameters
         ----------
-        ngram_a : tuple[str]
+        ngram_a: tuple[str]
             The n-gram to check if it is a sub-ngram.
-        ngram_b : tuple[str]
+        ngram_b: tuple[str]
             The n-gram to check against.
 
         Returns
         -------
-        bool
+        is_sub: bool
             True if ngram_a is a sub-ngram of ngram_b, False otherwise.
 
         Examples
@@ -1395,12 +1405,12 @@ class NgramSetPattern(Pattern):
 
         Parameters
         ----------
-        ngrams : PatternValueType
+        ngrams: PatternValueType
             The set of n-grams to filter.
 
         Returns
         -------
-        PatternValueType
+        maximal_ngrams: PatternValueType
             The filtered set of maximal n-grams, excluding the rest.
 
         Examples
@@ -1422,9 +1432,11 @@ class NgramSetPattern(Pattern):
         """
         Return the set of every individual sub-ngram for each ngram from the given pattern.
 
+        For an NgramSetPattern an atomic pattern is a set containing just one ngram.
+
         Returns
         -------
-        set[Self]
+        atoms: set[Self]
             A set of atomic patterns derived from the n-grams.
 
         Examples
@@ -1451,7 +1463,7 @@ class NgramSetPattern(Pattern):
 
         Returns
         -------
-        Optional[Self]
+        min: Optional[Self]
             The minimal n-gram set pattern, which is an empty frozenset.
             `None` if undefined
         
@@ -1469,9 +1481,9 @@ class CartesianPattern(Pattern):
 
     Attributes
     ----------
-    PatternValueType :
+    PatternValueType:
         The type of the pattern's value, which is a frozendict mapping dimension names to Pattern instances.
-    DimensionTypes : dict[str, Type[Pattern]]
+    DimensionTypes: dict[str, Type[Pattern]]
         Optional mapping from dimension names to specific Pattern types for parsing.
     
     Properties
@@ -1494,7 +1506,7 @@ class CartesianPattern(Pattern):
 
         Returns
         -------
-        str
+        representation: str
             A string representing the dictionary form of the Cartesian pattern.
 
         Examples
@@ -1511,12 +1523,12 @@ class CartesianPattern(Pattern):
 
         Parameters
         ----------
-        value : dict
+        value: dict
             A dictionary mapping dimension names to pattern descriptions or Pattern instances.
 
         Returns
         -------
-        PatternValueType
+        value: PatternValueType
             The preprocessed frozendict of dimension names to Pattern instances.
 
         Raises
@@ -1566,7 +1578,7 @@ class CartesianPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another Cartesian pattern to intersect with.
 
         Returns
@@ -1594,7 +1606,7 @@ class CartesianPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another Cartesian pattern to union with.
 
         Returns
@@ -1626,7 +1638,7 @@ class CartesianPattern(Pattern):
 
         Parameters
         ----------
-        other : Self
+        other: Self
             Another Cartesian pattern to subtract from self.
 
         Returns
@@ -1658,7 +1670,7 @@ class CartesianPattern(Pattern):
 
         Returns
         -------
-        set[Self]
+        atoms: set[Self]
             A set of atomic Cartesian patterns.
 
         Examples
@@ -1688,7 +1700,7 @@ class CartesianPattern(Pattern):
 
         Returns
         -------
-        int
+        count: int
             The total number of atomic subpatterns across all dimensions.
 
         Examples
@@ -1711,7 +1723,7 @@ class CartesianPattern(Pattern):
 
         Returns
         -------
-        Optional[Self]
+        min: Optional[Self]
             The minimal Cartesian pattern or None if any subpattern has no minimum.
 
         Examples
@@ -1737,7 +1749,7 @@ class CartesianPattern(Pattern):
 
         Returns
         -------
-        Optional[Self]
+        max: Optional[Self]
             The maximal Cartesian pattern or None if any subpattern has no maximum.
 
         Examples
@@ -1763,7 +1775,7 @@ class CartesianPattern(Pattern):
 
         Returns
         -------
-        Optional[set[Self]]
+        max_atoms: Optional[set[Self]]
             A set of maximal atomic Cartesian patterns.
 
         Examples
@@ -1796,12 +1808,12 @@ class CartesianPattern(Pattern):
 
         Parameters
         ----------
-        item : str
+        item: str
             The dimension name.
 
         Returns
         -------
-        Pattern
+        pattern: Pattern
             The Pattern instance corresponding to the dimension.
 
         Examples

--- a/paspailleur/pattern_structures/pattern.py
+++ b/paspailleur/pattern_structures/pattern.py
@@ -73,7 +73,7 @@ class Pattern:
 
         Returns
         -------
-        PatternValueType
+        value: PatternValueType
             The value of the pattern.
         
         Examples
@@ -91,7 +91,7 @@ class Pattern:
         
         Returns
         -------
-        bool
+        flag: bool
             True if the pattern can be met, False otherwise.
         
         Examples
@@ -113,7 +113,7 @@ class Pattern:
 
         Returns
         -------
-        bool
+        flag: bool
             True if the pattern can be joined, False otherwise.
         
         Examples
@@ -135,7 +135,7 @@ class Pattern:
 
         Returns
         -------
-        bool
+        flag: bool
             True if the pattern can be atomized, False otherwise.
         
         Examples
@@ -157,7 +157,7 @@ class Pattern:
 
         Returns
         -------
-        bool
+        flag: bool
             True if the pattern can be subtracted, False otherwise.
         
         Examples
@@ -178,7 +178,7 @@ class Pattern:
 
         Parameters
         ----------
-        other : Self
+        other: Self
             The other pattern to intersect with.
 
         Returns
@@ -210,7 +210,7 @@ class Pattern:
 
         Parameters
         ----------
-        other : Self
+        other: Self
             The other pattern to union with.
 
         Returns
@@ -271,6 +271,11 @@ class Pattern:
         """
         Return a string representation of the pattern
         
+        Returns
+        -------
+        representation: str
+            A representation of the pattern.
+
         Examples
         --------
         >>> p = Pattern("text")
@@ -285,7 +290,7 @@ class Pattern:
 
         Returns
         -------
-        int
+        count: int
             The number of atomic patterns.
         
         Examples
@@ -313,7 +318,7 @@ class Pattern:
 
         Returns
         -------
-        PatternValueType
+        parsed: PatternValueType
             The parsed pattern value.
 
         Examples
@@ -335,7 +340,7 @@ class Pattern:
 
         Returns
         -------
-        PatternValueType
+        value: PatternValueType
             The preprocessed value.
         
         Examples
@@ -356,7 +361,7 @@ class Pattern:
 
         Returns
         -------
-        bool
+        comparison: bool
             True if self is equal to other, False otherwise.
         
         Examples
@@ -365,7 +370,6 @@ class Pattern:
         >>> p2 = Pattern("A")
         >>> p1 == p2
         True
-
         >>> p1= Pattern("A")
         >>> p2= Pattern("B")
         p1 == p2
@@ -384,7 +388,7 @@ class Pattern:
 
         Returns
         -------
-        bool
+        comparison: bool
             True if self is less precise or equal to other, False otherwise.
         
         Examples
@@ -410,7 +414,7 @@ class Pattern:
 
         Returns
         -------
-        bool
+        comparison: bool
             True if self is less precise than other, False otherwise.
         
         Examples
@@ -419,7 +423,6 @@ class Pattern:
         >>> p2 = Pattern("A | B")
         >>> p1 < p2
         True
-
         >>> p1 = Pattern("A")
         >>> p2 = Pattern("A")
         >>> p1 < p2
@@ -562,7 +565,7 @@ class Pattern:
 
         Returns
         -------
-        Self
+        sub: Self
             True if self is less precise or equal to other.
         
         Examples
@@ -585,7 +588,7 @@ class Pattern:
 
         Returns
         -------
-        Self
+        super: Self
             True if self is more precise or equal to other.
         
         Examples
@@ -603,7 +606,7 @@ class Pattern:
 
         Returns
         -------
-        int
+        hash_code: int
             The hash value of the pattern.
         
         Examples
@@ -618,6 +621,11 @@ class Pattern:
     def atomic_patterns(self) -> set[Self]:
         """
         Return the set of all less precise patterns that cannot be obtained by intersection of other patterns.
+
+        Returns
+        -------
+        atoms: set[Self]
+            A set of atomic patterns.
 
         Raises
         ------
@@ -639,7 +647,7 @@ class Pattern:
 
         Returns
         -------
-        Optional[Self]
+        min: Optional[Self]
             The minimal pattern or None if undefined.
         
         Examples
@@ -657,7 +665,7 @@ class Pattern:
 
         Returns
         -------
-        Optional[Self]
+        max: Optional[Self]
             The maximal pattern or None if undefined.
         
         Examples
@@ -675,7 +683,7 @@ class Pattern:
 
         Returns
         -------
-        Optional[set[Self]]
+        max_atoms: Optional[set[Self]]
             The set of maximal atomic patterns or None if undefined.
         
         Examples

--- a/paspailleur/pattern_structures/pattern_structure.py
+++ b/paspailleur/pattern_structures/pattern_structure.py
@@ -18,23 +18,33 @@ from paspailleur.algorithms import base_functions as bfuncs, mine_equivalence_cl
 """
 class PatternStructure:
     """
-    A class to represent a structure for managing patterns in a formal context.
+    A class to process complex datasets where every row (called object) is described by one pattern.
 
+    All patterns should be of the same class defined by PatternType attribute.
+
+    References
+    ----------
+    Ganter, B., & Kuznetsov, S. O. (2001, July). Pattern structures and their projections. In International conference on conceptual structures (pp. 129-142). Berlin, Heidelberg: Springer Berlin Heidelberg.
+    
     Attributes
     ----------
-    PatternType : TypeVar
+    PatternType: TypeVar
         A type variable bound to the Pattern class.
     
     Private Attributes
     ------------------
-    _object_irreducibles : Optional[dict[PatternType, fbarray]]
+    _object_irreducibles: Optional[dict[PatternType, fbarray]]
         Patterns introduced by objects.
-    _object_names : Optional[list[str]]
+    _object_names: Optional[list[str]]
         Names of the objects.
-    _atomic_patterns : Optional[OrderedDict[PatternType, fbarray]]
+    _atomic_patterns: Optional[OrderedDict[PatternType, fbarray]]
         Smallest nontrivial patterns.
-    _atomic_patterns_order : Optional[list[fbarray]]
-        Order of atomic patterns.
+    _atomic_patterns_order: Optional[list[fbarray]]
+        Partial order on atomic patterns meaning that some atomic patterns can be incomparable.
+        _atomic_patterns_order[i][j] == True would mean that i-th atomic pattern is less precise than j-th atomic pattern.
+        _atomic_patterns_order[i][j] == False can mean both that j-th atomic pattern is less precise than i-th atomic pattern and that i-th and j-th atomic patterns can not be compared.
+
+
 
     Properties
     ----------
@@ -61,7 +71,7 @@ class PatternStructure:
 
         Parameters
         ----------
-        pattern_type : Type[Pattern], optional
+        pattern_type: Type[Pattern], optional
             The type of Pattern to use (default is Pattern).
         """
         self.PatternType = pattern_type
@@ -82,14 +92,14 @@ class PatternStructure:
 
         Parameters
         ----------
-        pattern : PatternType
+        pattern: PatternType
             The pattern for which to compute the extent.
-        return_bitarray : bool, optional
+        return_bitarray: bool, optional
             If True, returns the extent as a bitarray (default is False).
 
         Returns
         -------
-        Union[set[str], fbarray]
+        extent: Union[set[str], fbarray]
             The extent of the pattern, either as a set of object names or a bitarray.
 
         Raises
@@ -120,12 +130,12 @@ class PatternStructure:
 
         Parameters
         ----------
-        objects : Union[Collection[str], fbarray]
+        objects: Union[Collection[str], fbarray]
             The objects for which to compute the intent.
 
         Returns
         -------
-        PatternType
+        intent: PatternType
             The intent of the given objects.
 
         Raises
@@ -165,14 +175,14 @@ class PatternStructure:
 
         Parameters
         ----------
-        object_descriptions : dict[str, PatternType]
+        object_descriptions: dict[str, PatternType]
             A dictionary mapping object names to their corresponding patterns.
-        compute_atomic_patterns : bool, optional
+        compute_atomic_patterns: bool, optional
             If True, computes atomic patterns. If None, tries to infer whether computation is possible (default is None).
-        min_atom_support : Union[int, float], optional
+        min_atom_support: Union[int, float], optional
             Minimum support threshold for an atomic pattern to be retained (default is 0).
             If a float between 0 and 1, it is interpreted as a proportion of total objects.
-        use_tqdm : bool, optional
+        use_tqdm: bool, optional
             If True, displays a progress bar when computing atomic patterns (default is True).
 
         Examples
@@ -205,13 +215,13 @@ class PatternStructure:
 
     def init_atomic_patterns(self, min_support: Union[int, float] = 0, use_tqdm: bool = False):
         """
-        Compute the set of all patterns that cannot be obtained by intersection of other patterns
+        Compute the set of all patterns that cannot be obtained by join of other patterns
 
         Parameters
         ----------
-        min_support : Union[int, float], optional
+        min_support: Union[int, float], optional
             Minimum number or proportion of objects a pattern must describe to be considered atomic (default is 0).
-        use_tqdm : bool, optional
+        use_tqdm: bool, optional
             If True, displays a progress bar during computation (default is False).
 
         Raises
@@ -273,7 +283,7 @@ class PatternStructure:
 
         Returns
         -------
-        PatternType
+        min: PatternType
             The minimal pattern found in the structure.
 
         Raises
@@ -301,7 +311,7 @@ class PatternStructure:
 
         Returns
         -------
-        PatternType
+        max: PatternType
             The maximal pattern found in the structure.
 
         Raises
@@ -330,7 +340,7 @@ class PatternStructure:
 
         Returns
         -------
-        set[PatternType]
+        max_atoms: set[PatternType]
             A set of maximal atomic patterns.
 
         Examples
@@ -353,7 +363,7 @@ class PatternStructure:
 
         Returns
         -------
-        OrderedDict[PatternType, set[str]]
+        atoms: OrderedDict[PatternType, set[str]]
             An ordered dictionary mapping atomic patterns to their extents (object names).
 
         Examples
@@ -370,7 +380,7 @@ class PatternStructure:
 
         Returns
         -------
-        int
+        count: int
             The number of atomic patterns.
 
         Examples
@@ -383,13 +393,13 @@ class PatternStructure:
     @property
     def atomic_patterns_order(self) -> dict[PatternType, set[PatternType]]:
         """
-        Return the partial order of atomic patterns by extent inclusion.
+        Return the partial order of atomic patterns, i.e. for every atomic pattern show all its atomic super-patterns.
 
         Each pattern maps to the set of patterns that strictly subsume it.
 
         Returns
         -------
-        dict[PatternType, set[PatternType]]
+        order: dict[PatternType, set[PatternType]]
             A dictionary representing the ordering of atomic patterns.
             Keys are atomic patterns, values are sets of greater atomic patterns.
 
@@ -416,7 +426,7 @@ class PatternStructure:
 
         Returns
         -------
-        dict[PatternType, set[str]]
+        premaximals: dict[PatternType, set[str]]
             A dictionary mapping premaximal patterns to their extents.
 
         Examples
@@ -445,16 +455,16 @@ class PatternStructure:
 
         Parameters
         ----------
-        return_extents : bool, optional
+        return_extents: bool, optional
             If True, returns extents along with patterns (default is True).
-        return_bitarrays : bool, optional
+        return_bitarrays: bool, optional
             If True, returns extents as bitarrays (default is False).
-        kind : Literal, optional
+        kind: Literal, optional
             Iteration strategy: 'bruteforce', 'ascending', or 'ascending controlled' (default is 'bruteforce').
 
         Yields
         ------
-        Union[PatternType, tuple[PatternType, set[str]], tuple[PatternType, fbarray]]
+        pattern_data: Union[PatternType, tuple[PatternType, set[str]], tuple[PatternType, fbarray]]
             Patterns optionally paired with their extent as a set of object names or bitarray.
 
         Examples
@@ -520,14 +530,14 @@ class PatternStructure:
 
         Parameters
         ----------
-        return_extents : bool, optional
+        return_extents: bool, optional
             If True, returns extents along with patterns (default is True).
-        return_bitarrays : bool, optional
+        return_bitarrays: bool, optional
             If True, returns extents as bitarrays (default is False).
 
         Yields
         ------
-        Union[PatternType, tuple[PatternType, set[str]], tuple[PatternType, fbarray]]
+        premaximal_data: Union[PatternType, tuple[PatternType, set[str]], tuple[PatternType, fbarray]]
             Premaximal patterns with optional extent representations.
 
         Examples
@@ -578,18 +588,18 @@ class PatternStructure:
 
         Parameters
         ----------
-        kind : Literal, optional
+        kind: Literal, optional
             Strategy for traversal: 'ascending' or 'ascending controlled' (default is 'ascending').
-        min_support : Union[int, float], optional
+        min_support: Union[int, float], optional
             Minimum support required for a pattern to be yielded (default is 0).
-        depth_first : bool, optional
+        depth_first: bool, optional
             If True, performs a depth-first traversal (default is True).
-        return_objects_as_bitarrays : bool, optional
+        return_objects_as_bitarrays: bool, optional
             If True, extents are returned as bitarrays; otherwise as sets (default is False).
 
         Yields
         ------
-        Iterator or Generator
+        pattern_info: Iterator or Generator
             Yields patterns and their extents.
 
         Examples
@@ -637,18 +647,24 @@ class PatternStructure:
             Iterator[PatternType], 
             Iterator[tuple[PatternType, PatternType]]]:
         """
-        Iterate over the atomic pattern combinations (keys) that describe given patterns.
+        Iterate over the keys that describe given patterns.
+
+        Keys (also known as minimal generators) of a pattern are the least precise subpatterns that describe the very same objects as the pattern.
+
+        Reference
+        ---------
+        Buzmakov, A., Dudyrev, E., Kuznetsov, S. O., Makhalova, T., & Napoli, A. (2024). Data complexity: An FCA-based approach. International Journal of Approximate Reasoning, 165, 109084.
 
         Parameters
         ----------
-        patterns : Union[PatternType, Iterable[PatternType]]
+        patterns: Union[PatternType, Iterable[PatternType]]
             A pattern or list of patterns to decompose into atomic keys.
-        max_length : Optional[int], optional
+        max_length: Optional[int], optional
             Maximum length of key combinations (default is None).
 
         Yields
         ------
-        Union[PatternType, tuple[PatternType, PatternType]]
+        keys: Union[PatternType, tuple[PatternType, PatternType]]
             Keys of the input patterns or (key, original pattern) pairs.
 
         Examples
@@ -676,24 +692,31 @@ class PatternStructure:
         """
         Iterate over subgroups that satisfy a quality threshold.
 
+        A subgroup is a pattern whose extent is very similar to the set of goal_objects.
+        The similarity is measured by quality_measure and is lower-bounded by qulity_threshold.
+
+        References
+        ----------
+        Atzmueller, M. (2015). Subgroup discovery. Wiley Interdisciplinary Reviews: Data Mining and Knowledge Discovery, 5(1), 35-49.
+
         Parameters
         ----------
-        goal_objects : Union[set[str], bitarray]
+        goal_objects: Union[set[str], bitarray]
             Set or bitarray of target objects.
-        quality_measure : Literal
+        quality_measure: Literal
             Metric to evaluate subgroups (e.g., 'Accuracy', 'F1', 'WRAcc').
-        quality_threshold : float
+        quality_threshold: float
             Minimum value for the selected quality measure.
-        kind : Literal, optional
+        kind: Literal, optional
             Subgroup mining strategy (currently only 'bruteforce' supported).
-        max_length : Optional[int], optional
+        max_length: Optional[int], optional
             Maximum length of subgroups (default is None).
-        return_objects_as_bitarrays : bool, optional
+        return_objects_as_bitarrays: bool, optional
             If True, extents are returned as bitarrays (default is False).
 
         Yields
         ------
-        Iterator[tuple[Pattern, Union[set[str], bitarray], float]]
+        subs: Iterator[tuple[Pattern, Union[set[str], bitarray], float]]
             Tuples of (pattern, extent, quality).
 
         Examples
@@ -736,24 +759,24 @@ class PatternStructure:
             list[tuple[set[str], PatternType]], 
             list[tuple[fbarray, PatternType]]]:
         """
-        Mine formal concepts (extent-intent pairs) from the pattern structure.
+        Mine pattern concepts (extent-intent pairs) from the pattern structure.
 
         Parameters
         ----------
-        min_support : Union[int, float], optional
+        min_support: Union[int, float], optional
             Minimum support required for concepts (default is 0).
-        min_delta_stability : Union[int, float], optional
+        min_delta_stability: Union[int, float], optional
             Minimum delta stability for concept filtering (default is 0).
-        algorithm : Literal, optional
+        algorithm: Literal, optional
             Algorithm used for mining: 'CloseByOne object-wise' or 'gSofia' (default selects automatically).
-        return_objects_as_bitarrays : bool, optional
+        return_objects_as_bitarrays: bool, optional
             If True, returns extents as bitarrays (default is False).
-        use_tqdm : bool, optional
+        use_tqdm: bool, optional
             If True, displays a progress bar (default is False).
 
         Returns
         -------
-        Union[list[tuple[set[str], PatternType]], list[tuple[fbarray, PatternType]]]
+        concepts: Union[list[tuple[set[str], PatternType]], list[tuple[fbarray, PatternType]]]
             A list of concept tuples, each containing an extent and its corresponding intent.
         
         Examples
@@ -825,24 +848,24 @@ class PatternStructure:
 
         Parameters
         ----------
-        basis_name : Literal, optional
+        basis_name: Literal, optional
             Type of basis used for implications (default is "Canonical Direct").
-        min_support : Union[int, float], optional
+        min_support: Union[int, float], optional
             Minimum support for implications (default is 0).
-        min_delta_stability : Union[int, float], optional
+        min_delta_stability: Union[int, float], optional
             Minimum delta stability (default is 0).
-        max_key_length : Optional[int], optional
+        max_key_length: Optional[int], optional
             Maximum length of keys (default is None).
-        algorithm : Literal, optional
+        algorithm: Literal, optional
             Concept mining algorithm to use (default is None).
-        reduce_conclusions : bool, optional
+        reduce_conclusions: bool, optional
             If True, reduces the size of implication conclusions (default is False).
-        use_tqdm : bool, optional
+        use_tqdm: bool, optional
             If True, displays a progress bar (default is False).
 
         Returns
         -------
-        dict[PatternType, PatternType]
+        implications: dict[PatternType, PatternType]
             A dictionary mapping premises to conclusions in the implication basis.
         
         Examples
@@ -881,18 +904,18 @@ class PatternStructure:
 
         Parameters
         ----------
-        premises : Iterable[PatternType]
+        premises: Iterable[PatternType]
             The premises to base implications on.
-        pseudo_close_premises : bool, optional
+        pseudo_close_premises: bool, optional
             Whether to pseudo-close the premises (default is False).
-        reduce_conclusions : bool, optional
+        reduce_conclusions: bool, optional
             If True, reduces conclusions to minimal additions (default is False).
-        use_tqdm : bool, optional
+        use_tqdm: bool, optional
             If True, displays progress bars (default is False).
 
         Returns
         -------
-        Union[dict[PatternType, PatternType], OrderedDict[PatternType, PatternType]]
+        premises: Union[dict[PatternType, PatternType], OrderedDict[PatternType, PatternType]]
             A mapping from premises to conclusions.
         
         Examples
@@ -948,18 +971,20 @@ class PatternStructure:
         """
         Compute the immediate successor patterns of a given pattern.
 
+        The immediate successor patternsare the next more precise patterns.
+
         Parameters
         ----------
-        pattern : PatternType
+        pattern: PatternType
             The pattern to compute successors for.
-        return_extents : bool, optional
+        return_extents: bool, optional
             If True, returns extents along with patterns (default is False).
-        return_objects_as_bitarrays : bool, optional
+        return_objects_as_bitarrays: bool, optional
             If True, extents are returned as bitarrays instead of sets (default is False).
 
         Returns
         -------
-        Union[set[PatternType], dict[PatternType, set[str]], dict[PatternType, fbarray]]
+        next_patterns: Union[set[PatternType], dict[PatternType, set[str]], dict[PatternType, fbarray]]
             Either a set of successor patterns or a mapping of successors to extents.
 
         Examples
@@ -1008,12 +1033,12 @@ class PatternStructure:
 
         Parameters
         ----------
-        pattern : Pattern
+        pattern: Pattern
             The pattern for which to compute support.
 
         Returns
         -------
-        int
+        support: int
             The number of objects (support count) covered by the pattern.
 
         Examples
@@ -1031,12 +1056,12 @@ class PatternStructure:
 
         Parameters
         ----------
-        pattern : Pattern
+        pattern: Pattern
             The pattern for which to compute frequency.
 
         Returns
         -------
-        float
+        frequency: float
             The frequency of the pattern as a fraction between 0 and 1.
 
         Examples
@@ -1056,12 +1081,12 @@ class PatternStructure:
 
         Parameters
         ----------
-        pattern : Pattern
+        pattern: Pattern
             The pattern for which to compute delta stability.
 
         Returns
         -------
-        int
+        delta_s: int
             The delta stability value.
 
         Examples
@@ -1086,12 +1111,12 @@ class PatternStructure:
 
         Parameters
         ----------
-        extent : Union[bitarray, set[str]]
+        extent: Union[bitarray, set[str]]
             The extent to convert. If a bitarray is provided, each set bit is mapped to its corresponding object name.
 
         Returns
         -------
-        set[str]
+        readable: set[str]
             The human-readable extent as a set of object names.
 
         Examples


### PR DESCRIPTION
* Added docstrings and examples

* Fixed an error with the docstrings

* Added docstrings and examples

* Fixed an error with the docstrings

* corrected the docstrings

* docstrings done for the pattern_structure file

* Added the variable names to the returns of pattern.py and corrected some alingment issues

* Added variable names for the returns of built_in_pattern.py and corrected some alignment issues

* Added the variable names to the returns of pattern_structure.py

* Deleted an empty line for better spacing of lines

* Corrected some docstrings errors and added som extra info

---------